### PR TITLE
Webpack --uglify compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "noImplicitAny": false,
     "sourceMap": false,


### PR DESCRIPTION
Uglify doesn't seem to like it when es6-style '=>' arrow functions are used in transpiled .js files.